### PR TITLE
Add the standard minimum build plate dimensions

### DIFF
--- a/body/README.md
+++ b/body/README.md
@@ -13,6 +13,8 @@ You will need to print the following parts in order to build your OpenBot.
 3) phone_mount_bottom ([STL](cad/phone_mount/phone_mount_bottom.stl), [STEP](cad/phone_mount/phone_mount_bottom.step))
 4) phone_mount_top ([STL](cad/phone_mount/phone_mount_top.stl), [STEP](cad/phone_mount/phone_mount_top.step))
 
+For the above parts, your build plate needs to be at least 240mmx150mm.
+
 Since a lot of common 3D printers have a smaller build volume, we have also made a [slim body](cad/slim_body/README.md) which fits on a 220mmx220mm build plate at 45 degrees.
 
 For printing on 3D printers with even smaller build volumes, there is also a [glueable body](cad/glue_body/README.md) which fits on a 150mmx140mm build plate. Thanks to @sloretz.


### PR DESCRIPTION
Adds a line describing what the minimal build plate dimensions should be for the standard (not slim) body.