### PR TITLE
Enable android build action with gradle build cache and path filter

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           cd android
           ./gradlew lint
-      # - name: Build
-      #   run: |
-      #     cd android
-      #     ./gradlew build
+      - name: Build
+        run: |
+          cd android
+          ./gradlew build

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,6 +26,12 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
       - name: Style
         run: |
           cd android

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,8 +6,14 @@ name: Java CI with Gradle
 on:
   push:
     branches: [ master ]
+    paths:
+    - 'android/**'
+    - '.github/workflows/gradle.yml'
   pull_request:
     branches: [ master ]
+    paths:
+    - 'android/**'
+    - '.github/workflows/gradle.yml'
 
 jobs:
   build:


### PR DESCRIPTION
So this is part 1 of https://github.com/intel-isl/OpenBot/issues/65
Since the contribution guidelines mentioned to make the PR's as small as possible, I'm submitting this as a separate PR and a different one will be made for the artifact uploads.

Regarding gradle cache, it stores a cache files with an id that has a has of the gradle files in it and the os version. This is just copied from the [github example](https://github.com/actions/cache/blob/main/examples.md#java---gradle), but it means that this is ready for when multiple os's are used and that if the gradle build files would change, it is a different cache as well, avoiding build issues related to gradle cache. From my builds([without](https://github.com/francisduvivier/OpenBot/runs/1184517379?check_suite_focus=true), [with](https://github.com/francisduvivier/OpenBot/runs/1184672476?check_suite_focus=true)), I see that this cache currently already cuts almost 1 minute from the build. 