### PR TITLE
Upload Android Debug apk to Artifacts in Actions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -44,3 +44,8 @@ jobs:
         run: |
           cd android
           ./gradlew build
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: app-debug.apk
+          path: android/app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
Anoter small PR for https://github.com/intel-isl/OpenBot/issues/65.
This one will make the app-debug.apk avaibable as a build artifact.