### PR TITLE
Upload android debug apk on Release

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,3 +45,4 @@ jobs:
         with:
           name: app-debug.apk
           path: android/app/build/outputs/apk/debug/app-debug.apk
+

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,7 +19,9 @@ jobs:
   build:
     name: Gradle Checks
     runs-on: ubuntu-latest
-
+    defaults:
+          run:
+            working-directory: android
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 1.8
@@ -33,17 +35,11 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
       - name: Style
-        run: |
-          cd android
-          ./gradlew checkStyle
+        run: ./gradlew checkStyle
       - name: Lint
-        run: |
-          cd android
-          ./gradlew lint
+        run: ./gradlew lint
       - name: Build
-        run: |
-          cd android
-          ./gradlew build
+        run: ./gradlew build
       - name: Upload
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -27,6 +27,9 @@ jobs:
         run: |
           ./gradlew assembleDebug
           echo "::set-output name=debug_apk_path::$(pwd)/app/build/outputs/apk/debug/app-debug.apk"
+      - name: Specify Release Asset Name using tag [${{github.event.release.tag_name}}]
+        id: make_asset_name
+        run: echo "::set-output name=asset_name::OpenBot-$(echo ${{github.event.release.tag_name}}| sed 's/[^-a-zA-Z0-9.]/_/g'| sed 's/^v//').apk"
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
@@ -35,5 +38,5 @@ jobs:
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ${{ steps.assemble_debug_apk.outputs.debug_apk_path }}
-          asset_name: app-debug.apk
+          asset_name: ${{steps.make_asset_name.outputs.asset_name}}
           asset_content_type: application/vnd.android.package-archive

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -34,7 +34,7 @@ jobs:
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ${{ steps.assemble_debug_apk.outputs.debug_apk_path }}

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,39 @@
+on:
+  release:
+    types:
+      - published # We are using published instead of created because otherwise, it would never trigger if it was first created as a draft and then published.
+
+name: Upload Android Apk to Release
+
+jobs:
+  upload-apk-to-release:
+    name: Add Android Debug Apk to Release Assets
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: android
+    steps:
+      - uses: actions/checkout@v2
+      - name: Print Release Url
+        run: echo "${{ github.event.release.html_url }}"
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Assemble Debug Apk
+        id: assemble_debug_apk
+        run: |
+          ./gradlew assembleDebug
+          echo "::set-output name=debug_apk_path::$(pwd)/app/build/outputs/apk/debug/app-debug.apk"
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ steps.assemble_debug_apk.outputs.debug_apk_path }}
+          asset_name: app-debug.apk
+          asset_content_type: application/vnd.android.package-archive

--- a/android/README.md
+++ b/android/README.md
@@ -6,12 +6,12 @@ Our application is derived from the [TensorFlow Lite Object Detection Android De
 
 ### Prerequisites
 
-- Setup [Android Studio](https://developer.android.com/studio/index.html)
+- [Android Studio 3.2 or later](https://developer.android.com/studio/index.html) for building and installing the apk, or otherwise download the apk from the assets of the [latest release](https://github.com/intel-isl/OpenBot/releases/latest).
 - Android device and Android development environment with minimum API 21
-- Android Studio 3.2 or later
 
 ### Building
 
+- In case you are using the apk from the assets of the [latest release](https://github.com/intel-isl/OpenBot/releases/latest), you can skip the below steps and instead just [install](https://www.lifewire.com/install-apk-on-android-4177185) it on your phone directly. Note that that apk is signed with a debug key.
 - Open Android Studio and select *Open an existing Android Studio project*.
 - Select the OpenBot/android directory and click OK.
 - Confirm Gradle Sync if neccessary.


### PR DESCRIPTION
The last PR for #65 .
This PR's hooks in to release publish events to automatically upload the android apk for this release. This PR affects the way of working for release, so I understand if you do not want to accept it. But I just wanted to finish my proposed tasks for #65 .

Here is an [example release](https://github.com/francisduvivier/OpenBot/releases/tag/v0.1.1-test) with an automatically uploaded apk, and a the [GitHub Action run](https://github.com/francisduvivier/OpenBot/runs/1194010562?check_suite_focus=true) for that.

Important here is that this will not trigger when you just push a tag, it will only trigger when a release is made in GitHub.
If we would also want it for tag pushes, that is possible, but then it would need to first create the release as well and it would need conditional logic for the case of a tag with no release yet and a manual release in GitHub. Or 1 way of working would need to be chosen.

Since last time a release with notes was created and for keeping it as simple as possible I used the release trigger.

This will trigger on first publication, so if you first pre-release and then release, it would only trigger on the pre-release.

Lastly, the PR also has a small refactor for the gradle.yml for less duplication.

