### PR TITLE
Added backward compatibility for ImageUtils.getScreenOrientation for phones with API<30

### DIFF
--- a/android/app/src/main/java/org/openbot/env/ImageUtils.java
+++ b/android/app/src/main/java/org/openbot/env/ImageUtils.java
@@ -227,7 +227,9 @@ public class ImageUtils {
   }
 
   public static int getScreenOrientation(Activity activity) {
-    switch (activity.getDisplay().getRotation()) {
+    int rotation = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R?
+            activity.getDisplay().getRotation() : activity.getWindowManager().getDefaultDisplay().getRotation();
+    switch (rotation) {
       case Surface.ROTATION_270:
         return 270;
       case Surface.ROTATION_180:


### PR DESCRIPTION
[Fix for this issue](https://github.com/intel-isl/OpenBot/issues/206)